### PR TITLE
Change tsassert comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,28 +21,28 @@ You must be using TypeScript 3 (this is a peer dependency).
 Simply add a comment with the following structure to the end of the line, or on the line above:
 
 ```ts
-// @type: ExpectedTypeHere
+// @tsassert: ExpectedTypeHere
 ```
 
 Basic examples:
 
 ```ts
 // Assert variable types
-const myNumber = 1; // @type: number
+const myNumber = 1; // @tsassert: number
 
-// @type: number
+// @tsassert: number
 const myOtherNumber = 2;
 
 // Assert return type of function
-sendMessage('Hello'); // @type: Promise<string>
+sendMessage('Hello'); // @tsassert: Promise<string>
 
-// @type: Promise<string>
+// @tsassert: Promise<string>
 sendMessage('Hello again');
 
 // Assert type of class instance
-new MyClass(abc); // @type: MyClass<ABC>
+new MyClass(abc); // @tsassert: MyClass<ABC>
 
-// @type: MyClass<ABC>
+// @tsassert: MyClass<ABC>
 new MyClass(abc);
 ```
 
@@ -51,7 +51,7 @@ Example in tests:
 ```ts
 describe('my getter', () => {
   it('should return undefined if any values in the path are nullable', () => {
-    // @type: string | undefined
+    // @tsassert: string | undefined
     const result = get(obj, ['a', 'b', 'c']);
 
     expect(result).toBe(undefined);

--- a/assertions/fail.ts
+++ b/assertions/fail.ts
@@ -11,15 +11,15 @@ interface ABC {
   d: ['a', 'b', 'c'];
 }
 
-export const abc = {} as ABC | null; // @type: ABC
+export const abc = {} as ABC | null; // @tsassert: ABC
 
-export const result = removeNull(abc); // @type: ABC | null
+export const result = removeNull(abc); // @tsassert: ABC | null
 
-removeNull(abc); // @type: ABC | null
+removeNull(abc); // @tsassert: ABC | null
 
-export const c = abc?.a?.b.c; // @type string | number
+export const c = abc?.a?.b.c; // @tsassert string | number
 
-export const d = abc?.d; // @type ['a', 'b', 'c'] | undefined
+export const d = abc?.d; // @tsassert ['a', 'b', 'c'] | undefined
 
 class MyClass<T> {
   public input: T;
@@ -30,7 +30,7 @@ class MyClass<T> {
 }
 
 // tslint:disable-next-line:no-unused-expression
-new MyClass(abc); // @type: MyClass<CBA | null>
+new MyClass(abc); // @tsassert: MyClass<CBA | null>
 
-// @type: ABC
-removeNull(abc); // @type: ABC
+// @tsassert: ABC
+removeNull(abc); // @tsassert: ABC

--- a/assertions/pass.ts
+++ b/assertions/pass.ts
@@ -11,15 +11,15 @@ interface ABC {
   d: ['a', 'b', 'c'];
 }
 
-export const abc = {} as ABC | null; // @type: ABC | null
+export const abc = {} as ABC | null; // @tsassert: ABC | null
 
-export const result = removeNull(abc); // @type: ABC
+export const result = removeNull(abc); // @tsassert: ABC
 
-removeNull(abc); // @type: ABC
+removeNull(abc); // @tsassert: ABC
 
-export const c = abc?.a?.b.c; // @type string | number | undefined
+export const c = abc?.a?.b.c; // @tsassert string | number | undefined
 
-export const d = abc?.d; // @type ["a", "b", "c"] | undefined
+export const d = abc?.d; // @tsassert ["a", "b", "c"] | undefined
 
 class MyClass<T> {
   public input: T;
@@ -30,7 +30,7 @@ class MyClass<T> {
 }
 
 // tslint:disable-next-line:no-unused-expression
-new MyClass(abc); // @type: MyClass<ABC | null>
+new MyClass(abc); // @tsassert: MyClass<ABC | null>
 
-// @type: ABC
+// @tsassert: ABC
 removeNull(abc);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsassert",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jakesidsmith/tsassert",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Check TypeScript types against assertion comments",
   "publishConfig": {
     "access": "public"

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -9,6 +9,7 @@ import * as logger from './logger';
 import { indent, isTruthyString } from './utils';
 import { version } from './version';
 
+const COMMENT_PREFIX = '@tsassert';
 const MATCHES_GLOB = /(?:}|\)|\*+\/?|\.[t]sx?)$/;
 const MATCHES_LONELY_COMMENT = /^\s*?\/\/\s?@tsassert(?::|\s)\s*(.+?)\s*?$/;
 const MATCHES_TRAILING_COMMENT = /\/\/\s?@tsassert(?::|\s)\s*(.+?)\s*?$/;
@@ -25,7 +26,7 @@ const assert = (tree: Tree) => {
     return version();
   }
 
-  logger.log('\nChecking type assertion comments...\n');
+  logger.log(`\nChecking ${COMMENT_PREFIX} comments...\n`);
 
   const cwd = process.cwd();
 
@@ -149,7 +150,9 @@ const assert = (tree: Tree) => {
 
           if (lonelyResult) {
             if (result) {
-              errors.push(`${fileLine}Found 2 type comments for the same line`);
+              errors.push(
+                `${fileLine}Found 2 ${COMMENT_PREFIX} comments for the same line`
+              );
               return;
             } else {
               result = lonelyResult;
@@ -171,7 +174,7 @@ const assert = (tree: Tree) => {
               const type = checker.typeToString(typeNode);
 
               if (type !== comment) {
-                const message = `${fileLine}Type of "${variableName}" did not match type comment:`;
+                const message = `${fileLine}Type of "${variableName}" did not match ${COMMENT_PREFIX} comment:`;
 
                 errors.push({
                   message,
@@ -192,7 +195,7 @@ const assert = (tree: Tree) => {
               );
 
               if (type !== comment) {
-                const message = `${fileLine}Return type of "${functionName}" did not match type comment:`;
+                const message = `${fileLine}Return type of "${functionName}" did not match ${COMMENT_PREFIX} comment:`;
 
                 errors.push({
                   message,
@@ -251,7 +254,10 @@ const assert = (tree: Tree) => {
       }
     });
 
-    return logger.error('\nSome files failed tsassert checks.\n', true);
+    return logger.error(
+      `\nSome files failed ${COMMENT_PREFIX} checks.\n`,
+      true
+    );
   } else {
     if (!filesChecked) {
       logger.warn(
@@ -259,10 +265,10 @@ const assert = (tree: Tree) => {
       );
     } else if (!commentsChecked) {
       logger.warn(
-        '\nCould not find any type assertions in matched files.\nRun with --verbose to see patterns that were checked.\n'
+        `\nCould not find any ${COMMENT_PREFIX} comments in matched files.\nRun with --verbose to see patterns that were checked.\n`
       );
     } else {
-      logger.success('\nAll files passed tsassert checks.\n');
+      logger.success(`\nAll files passed ${COMMENT_PREFIX} checks.\n`);
     }
   }
 };

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -10,8 +10,8 @@ import { indent, isTruthyString } from './utils';
 import { version } from './version';
 
 const MATCHES_GLOB = /(?:}|\)|\*+\/?|\.[t]sx?)$/;
-const MATCHES_LONELY_COMMENT = /^\s*?\/\/\s?@type(?::|\s)\s*(.+?)\s*?$/;
-const MATCHES_TRAILING_COMMENT = /\/\/\s?@type(?::|\s)\s*(.+?)\s*?$/;
+const MATCHES_LONELY_COMMENT = /^\s*?\/\/\s?@tsassert(?::|\s)\s*(.+?)\s*?$/;
+const MATCHES_TRAILING_COMMENT = /\/\/\s?@tsassert(?::|\s)\s*(.+?)\s*?$/;
 const MATCHES_NODE_MODULES = /^node_modules/;
 
 interface AssertionError {


### PR DESCRIPTION
Change `@type` to `@tsassert` to prevent potential clashes with other tools, or accidental confusion with docs comments, etc.